### PR TITLE
Add breakpoint control via a command

### DIFF
--- a/Commands.sublime-commands
+++ b/Commands.sublime-commands
@@ -3,7 +3,7 @@
         "caption": "Preferences: Debugger Settings",
         "command": "edit_settings",
         "args": {
-          "base_file": "${packages}/sublime_db/debug.sublime-settings",
+          "base_file": "${packages}/sublime_db/debug.sublime-settings"
         }
     },
     {
@@ -42,5 +42,9 @@
         "caption" : "Debugger: Resume",
         "command" : "sublime_debug_resume"
     },
-    { "caption": "-", "id": "debug_end" },
+    {
+        "caption" : "Debugger: Toggle Breakpoint",
+        "command" : "sublime_debug_toggle_breakpoint"
+    },
+    { "caption": "-", "id": "debug_end" }
 ]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -5,6 +5,10 @@
         "command" : "sublime_debug_start"
     },
     {
+        "caption": "Toggle breakpoint",
+        "command": "sublime_debug_toggle_breakpoint"
+    },
+    {
         "caption" : "Stop debugging",
         "command" : "sublime_debug_stop"
     },
@@ -28,5 +32,5 @@
         "caption" : "Resume",
         "command" : "sublime_debug_resume"
     },
-    { "caption": "-", "id": "debug_end" },
+    { "caption": "-", "id": "debug_end" }
 ]

--- a/main/commands.py
+++ b/main/commands.py
@@ -28,6 +28,20 @@ class SublimeDebugOpenCommand(RunMainCommand):
 		assert main
 		main.show()
 
+class SublimeDebugToggleBreakpointCommand(RunMainCommand):
+	def run_main(self) -> None:
+		main = Main.forWindow(self.window, True)
+		assert main
+		view = self.window.active_view()
+		x, y = view.rowcol(view.sel()[0].begin())
+		line = x + 1
+		file = view.file_name()
+		breakpoint = main.breakpoints.get_breakpoint(file, line)
+		if breakpoint is not None:
+			main.breakpoints.remove_breakpoint(breakpoint)
+		else:
+			main.breakpoints.add_breakpoint(file, line)
+
 class SublimeDebugQuitCommand(RunMainCommand):
 	def run_main(self) -> None:
 		main = Main.forWindow(self.window)


### PR DESCRIPTION
I had some bugs with double clicks on the gutter to add breakpoints (maybe a plugin conflict or something) and I tough it would be nice to have a command to toggle a breakpoint at the cursor position.
With a real command like this it's easy to create a key binding and avoid using the mouse.