### PR TITLE
More adaptive colors

### DIFF
--- a/main/components/breakpoints_component.py
+++ b/main/components/breakpoints_component.py
@@ -144,7 +144,7 @@ class DebuggerComponent(ui.Component):
 		buttons = [] #type: List[ui.Component]
 		if self.state == RUNNING:
 			buttons = [
-				ui.Label("Running", width = 6),
+				ui.Label("Running", width = 6, color="white"),
 				ui.Button(self.listener.OnSettings, items = [
 					ui.Img(ui.Images.shared.settings)
 				]),
@@ -157,7 +157,7 @@ class DebuggerComponent(ui.Component):
 			]
 		if self.state == PAUSED:
 			buttons = [
-				ui.Label("Paused", width = 6),
+				ui.Label("Paused", width = 6, color="white"),
 				ui.Button(self.listener.OnSettings, items = [
 					ui.Img(ui.Images.shared.settings)
 				]),
@@ -179,7 +179,7 @@ class DebuggerComponent(ui.Component):
 			]
 		if self.state == STOPPED:
 			buttons = [
-				ui.Label(self.name, width = 6),
+				ui.Label(self.name, width = 6, color="white"),
 				ui.Button(self.listener.OnSettings, items = [
 					ui.Img(ui.Images.shared.settings)
 				]),
@@ -189,7 +189,7 @@ class DebuggerComponent(ui.Component):
 			]
 		if self.state == LOADING:
 			buttons = [
-				ui.Label(self.name, width = 6),
+				ui.Label(self.name, width = 6, color="white"),
 				ui.Button(self.listener.OnSettings, items = [
 					ui.Img(ui.Images.shared.settings)
 				]),

--- a/main/components/call_stack_component.py
+++ b/main/components/call_stack_component.py
@@ -40,7 +40,7 @@ class  CallStackComponent (ui.Component):
 		return [
 			ui.Panel(items = [
 				ui.Segment(items = [
-					ui.Label('Call Stack')
+					ui.Label('Call Stack', color="white")
 				]),
 				# FIXME?? Table should not take List
 				ui.Table(items = self.thread_components) #type: ignore 

--- a/main/components/console_component.py
+++ b/main/components/console_component.py
@@ -64,7 +64,7 @@ class EventLogComponent (ui.Component):
 		return [
 			ui.Panel(items = [
 				ui.Segment(items = [
-					ui.Label('Event Log')
+					ui.Label('Event Log', color="white")
 				]),
 				ui.Table(items = self.lines)
 			])

--- a/main/components/variable_component.py
+++ b/main/components/variable_component.py
@@ -68,7 +68,7 @@ class VariablesComponent (ui.Component):
 		self.dirty()
 	def render(self) -> ui.components:
 		items = [
-			ui.Segment(items = [ui.Label('Variables')])
+			ui.Segment(items = [ui.Label('Variables', color="white")])
 		] #type: List[ui.Component]
 
 		variables = [] #type: List[ui.Component]

--- a/ui/ui.css
+++ b/ui/ui.css
@@ -12,13 +12,16 @@ a {
 }
 
 .secondary {
-	--text-color: rgba(255, 255, 255, 0.5);
+	--text-color: color(var(--foreground) alpha(0.7));
 }
 .primary {
-	--text-color: rgba(255, 255, 255, 1.0);
+	--text-color: var(--foreground);
+}
+.white {
+	--text-color: var(--whitish);
 }
 .red {
-	--text-color: rgba(255, 0, 0, 1.0);
+	--text-color: var(--redish);
 }
  .medium {
 	line-height: 0.0rem;


### PR DESCRIPTION
This PR fixes the text contrast when the `Default.sublime-theme` is used.
Before:
![2018-10-31-112344_683x768_scrot](https://user-images.githubusercontent.com/22029477/47784625-6e9b1680-dd06-11e8-9a04-32353a23f302.png)

After:
![2018-10-31-120154_683x768_scrot](https://user-images.githubusercontent.com/22029477/47784628-6fcc4380-dd06-11e8-88a5-b10c39436f00.png)


**Changes**
* The primary colour is now the foreground colour of the color scheme (see [predifined variables](https://www.sublimetext.com/docs/3/minihtml.html#variables) for more info).
* The secondary colour is the foreground colour of the color scheme with a bit of opacity.
* Colours in the black box, for the `Call Stack`, `Variables`, `Event Log`, don't use the `primary color`, instead the are always white.